### PR TITLE
Add GraphGPS model

### DIFF
--- a/configs/gnn/gps_dec.yaml
+++ b/configs/gnn/gps_dec.yaml
@@ -1,0 +1,160 @@
+MetaArguments:
+  log_file_path: "text_embeddings_gemma_300m_dec.log"
+  node_file: "data/CrediBench/dec2024/vertices.csv"
+  edge_file: "data/CrediBench/dec2024/edges.csv"
+  target_file: "data/CrediBench/dec2024/targets.csv"
+  processed_location: "data/CrediBench/dec2024/processed_dir/pc1"
+  weights_directory: "data/weights/"
+  database_folder: "data/CrediBench/dec2024/"
+
+  # log_file_path: "text_embeddings_gemma_300m_oct.log"
+  # node_file: "data/CrediBench/oct2024/vertices.csv"
+  # edge_file: "data/CrediBench/oct2024/edges.csv"
+  # target_file: "data/CrediBench/oct2024/targets.csv"
+  # processed_location: "data/CrediBench/oct2024/processed_dir/pc1"
+  # weights_directory: "data/weights/"
+  # database_folder: "data/CrediBench/oct2024/"
+
+  # log_file_path: "text_embeddings_gemma_300m_nov.log"
+  # node_file: "data/CrediBench/nov2024/vertices.csv"
+  # edge_file: "data/CrediBench/nov2024/edges.csv"
+  # target_file: "data/CrediBench/nov2024/targets.csv"
+  # processed_location: "data/CrediBench/nov2024/processed_dir/pc1"
+  # weights_directory: "data/weights/"
+  # database_folder: "data/CrediBench/nov2024/"
+
+  target_col: "pc1"
+  target_index_name: 'nid'
+  target_index_col: 0
+  edge_src_col: "src"
+  edge_dst_col: "dst"
+  index_col: 0
+  encoder_dict:
+    pre: PRE
+  embedding_index_file: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m/dec2024_wetcontent_domains_index.pkl"
+  embedding_folder: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m"
+  is_scratch_location: false
+  global_seed: 42
+
+
+ExperimentArguments:
+  exp_args:
+    # 原始GPS配置 (GIN + Performer)
+    # GPS:
+    #   model_args:
+    #     model: "GPS"
+    #     num_layers: 3
+    #     hidden_channels: 256
+    #     num_neighbors: [30, 30, 30]
+    #     batch_size: 256
+    #     dropout: 0.1
+    #     lr: 0.001
+    #     weight_decay: 0.01
+    #     epochs: 80
+    #     patience: 10
+    #     runs: 1
+    #     device: 0
+    #     log_steps: 1
+    #     gps_heads: 4
+    #     gps_attn_type: "performer"
+    #     gps_attn_dropout: 0.1
+    #     gps_local_mpnn: "gin"
+    #   data_args:
+    #     task_name: "node-regression"
+    #     is_regression: true
+    #     num_test_shards: 2
+
+    # GPS + GatedGCN (论文推荐) + Multihead Attention
+    GPS_gatedgcn:
+      model_args:
+        model: "GPS"
+        num_layers: 3
+        hidden_channels: 256
+        num_neighbors: [30, 30, 30]
+        batch_size: 256  # GPS全局attention内存占用大，需要小batch
+        dropout: 0.1
+        lr: 0.001
+        weight_decay: 0.0
+        epochs: 100
+        patience: 10
+        runs: 3
+        device: 0
+        log_steps: 10
+        gps_heads: 1
+        gps_attn_type: "performer"
+        gps_attn_dropout: 0.1
+        gps_local_mpnn: "gatedgcn"
+      data_args:
+        task_name: "node-regression"
+        is_regression: true
+        num_test_shards: 2
+
+    # GPS + GAT作为local MPNN + Multihead Attention
+    # GPS_gat:
+    #   model_args:
+    #     model: "GPS"
+    #     num_layers: 3
+    #     hidden_channels: 256
+    #     num_neighbors: [30, 30, 30]
+    #     batch_size: 1024
+    #     dropout: 0.1
+    #     lr: 0.001
+    #     weight_decay: 0.0
+    #     epochs: 100
+    #     patience: 10
+    #     runs: 3
+    #     device: 0
+    #     log_steps: 10
+    #     gps_heads: 4
+    #     gps_attn_type: "multihead"
+    #     gps_attn_dropout: 0.1
+    #     gps_local_mpnn: "gat"
+    #   data_args:
+    #     task_name: "node-regression"
+    #     is_regression: true
+    #     num_test_shards: 2
+
+    # GPS + GIN + Multihead (公平对比: 与GAT相同的训练配置)
+    # GPS_multihead:
+    #   model_args:
+    #     model: "GPS"
+    #     num_layers: 3
+    #     hidden_channels: 256
+    #     num_neighbors: [30, 30, 30]
+    #     batch_size: 1024
+    #     dropout: 0.1
+    #     lr: 0.001
+    #     weight_decay: 0.0
+    #     epochs: 100
+    #     patience: 0
+    #     runs: 3
+    #     device: 0
+    #     log_steps: 10
+    #     gps_heads: 4
+    #     gps_attn_type: "multihead"
+    #     gps_attn_dropout: 0.1
+    #     gps_local_mpnn: "gin"
+    #   data_args:
+    #     task_name: "node-regression"
+    #     is_regression: true
+    #     num_test_shards: 2
+
+    # GAT baseline (用于对比)
+    # GAT:
+    #   model_args:
+    #     model: "GAT"
+    #     num_layers: 3
+    #     hidden_channels: 256
+    #     num_neighbors: [30, 30, 30]
+    #     batch_size: 1024
+    #     dropout: 0.1
+    #     lr: 0.001
+    #     epochs: 100
+    #     runs: 3
+    #     device: 0
+    #     log_steps: 10
+    #   data_args:
+    #     task_name: "node-regression"
+    #     is_regression: true
+    #     num_test_shards: 2
+

--- a/credipred/dataset/temporal_dataset.py
+++ b/credipred/dataset/temporal_dataset.py
@@ -46,6 +46,8 @@ class TemporalDataset(InMemoryDataset):
         pre_transform: Optional[Callable] = None,
         seed: int = 42,
         processed_dir: Optional[str] = None,
+        embedding_index_file: Optional[str] = None,
+        embedding_folder: Optional[str] = None,
     ):
         """Initialize the dataset configuration and load processed data if present.
 
@@ -82,6 +84,10 @@ class TemporalDataset(InMemoryDataset):
                 Random seed for dataset splitting.
             processed_dir : Optional[str]
                 Optional override for processed data directory.
+            embedding_index_file : Optional[str]
+                Path to the domain-to-embedding-file index pickle for PRE encoder.
+            embedding_folder : Optional[str]
+                Path to the folder containing embedding pickle files for PRE encoder.
         """
         self.node_file = node_file
         self.edge_file = edge_file
@@ -98,6 +104,8 @@ class TemporalDataset(InMemoryDataset):
         self.encoding = encoding
         self.seed = seed
         self._custome_processed_dir = processed_dir
+        self.embedding_index_file = embedding_index_file
+        self.embedding_folder = embedding_folder
         super().__init__(root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
@@ -143,6 +151,8 @@ class TemporalDataset(InMemoryDataset):
             path=node_path,
             index_col=0,
             encoders=self.encoding,
+            embedding_index_file=self.embedding_index_file,
+            embedding_folder=self.embedding_folder,
         )
         logging.info('***Feature Matrix Done***')
 

--- a/credipred/experiments/gnn_experiments/gnn_experiment.py
+++ b/credipred/experiments/gnn_experiments/gnn_experiment.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 import torch
 import torch.nn.functional as F
+import wandb
 from torch import Tensor
 from torch_geometric.loader import NeighborLoader
 from torcheval.metrics.functional import r2_score
@@ -38,7 +39,9 @@ def train(
     for batch in tqdm(train_loader, desc='Batchs', leave=False):
         optimizer.zero_grad()
         batch = batch.to(device)
-        preds = model(batch.x, batch.edge_index).squeeze()
+        # For GPS on a single large graph, use batch=None to enable global attention
+        # across ALL sampled nodes (not just within each seed's neighborhood)
+        preds = model(batch.x, batch.edge_index, batch=None).squeeze()
         targets = batch.y
         train_mask = batch.train_mask
         if train_mask.sum() == 0:
@@ -76,7 +79,9 @@ def train_(
     for batch in tqdm(train_loader, desc='Batchs', leave=False):
         optimizer.zero_grad()
         batch = batch.to(device)
-        preds = model(batch.x, batch.edge_index).squeeze()
+        # For GPS on a single large graph, use batch=None to enable global attention
+        # across ALL sampled nodes (not just within each seed's neighborhood)
+        preds = model(batch.x, batch.edge_index, batch=None).squeeze()
         targets = batch.y
         train_mask = batch.train_mask
         if train_mask.sum() == 0:
@@ -117,7 +122,9 @@ def evaluate(
     all_targets = []
     for batch in loader:
         batch = batch.to(device)
-        preds = model(batch.x, batch.edge_index).squeeze()
+        # For GPS on a single large graph, use batch=None to enable global attention
+        # across ALL sampled nodes (not just within each seed's neighborhood)
+        preds = model(batch.x, batch.edge_index, batch=None).squeeze()
         targets = batch.y
         mask = getattr(batch, mask_name)
         if mask.sum() == 0:
@@ -211,7 +218,17 @@ def run_gnn_baseline(
     global_best_val_loss = float('inf')
     best_state_dict = None
     logging.info('*** Training ***')
+
+    # Get current learning rate for logging
+    current_lr = model_arguments.lr
+    global_step = 0
+
     for run in tqdm(range(model_arguments.runs), desc='Runs'):
+        # Build GPS-specific attention kwargs if using GPS
+        gps_attn_kwargs = None
+        if model_arguments.model == 'GPS':
+            gps_attn_kwargs = {'dropout': model_arguments.gps_attn_dropout}
+
         model = Model(
             model_name=model_arguments.model,
             normalization=model_arguments.normalization,
@@ -220,13 +237,32 @@ def run_gnn_baseline(
             out_channels=model_arguments.embedding_dimension,
             num_layers=model_arguments.num_layers,
             dropout=model_arguments.dropout,
+            # GraphGPS specific parameters
+            gps_heads=model_arguments.gps_heads,
+            gps_attn_type=model_arguments.gps_attn_type,
+            gps_attn_kwargs=gps_attn_kwargs,
+            gps_local_mpnn=model_arguments.gps_local_mpnn,
         ).to(device)
-        optimizer = torch.optim.AdamW(model.parameters(), lr=model_arguments.lr)
+        optimizer = torch.optim.AdamW(
+            model.parameters(),
+            lr=model_arguments.lr,
+            weight_decay=model_arguments.weight_decay,
+        )
+
+        # Log model architecture to wandb (only on first run)
+        if run == 0:
+            wandb.watch(model, log='all', log_freq=100)
+
         loss_tuple_epoch_mse: List[Tuple[float, float, float, float, float]] = []
         loss_tuple_epoch_r2: List[Tuple[float, float, float]] = []
         epoch_avg_preds: List[List[float]] = []
         epoch_avg_targets: List[List[float]] = []
-        for _ in tqdm(range(1, 1 + model_arguments.epochs), desc='Epochs'):
+
+        # Early stopping variables
+        best_val_loss_in_run = float('inf')
+        epochs_without_improvement = 0
+
+        for epoch in tqdm(range(1, 1 + model_arguments.epochs), desc='Epochs'):
             _, _, batch_preds, batch_targets = train_(model, train_loader, optimizer)
             epoch_avg_preds.append(batch_preds)
             epoch_avg_targets.append(batch_targets)
@@ -237,6 +273,53 @@ def run_gnn_baseline(
             test_loss, test_mean_baseline_loss, test_random_baseline_loss, test_r2 = (
                 evaluate(model, test_loader, 'test_mask')
             )
+
+            # Log metrics to wandb
+            global_step += 1
+            current_lr = optimizer.param_groups[0]['lr']
+
+            # GPU memory tracking
+            gpu_memory_allocated = 0
+            gpu_memory_reserved = 0
+            gpu_utilization = 0
+            if torch.cuda.is_available():
+                gpu_memory_allocated = torch.cuda.memory_allocated(device) / 1e9  # GB
+                gpu_memory_reserved = torch.cuda.memory_reserved(device) / 1e9  # GB
+                gpu_max_memory = torch.cuda.max_memory_allocated(device) / 1e9  # GB
+
+            wandb.log({
+                # Training metrics
+                "train/loss": train_loss,
+                "train/r2": train_r2,
+
+                # Validation metrics
+                "val/loss": valid_loss,
+                "val/r2": valid_r2,
+                "val/mean_baseline_loss": valid_mean_baseline_loss,
+
+                # Test metrics
+                "test/loss": test_loss,
+                "test/r2": test_r2,
+                "test/mean_baseline_loss": test_mean_baseline_loss,
+                "test/random_baseline_loss": test_random_baseline_loss,
+
+                # Learning rate
+                "train/learning_rate": current_lr,
+
+                # GPU metrics
+                "gpu/memory_allocated_gb": gpu_memory_allocated,
+                "gpu/memory_reserved_gb": gpu_memory_reserved,
+                "gpu/max_memory_allocated_gb": gpu_max_memory if torch.cuda.is_available() else 0,
+
+                # Progress tracking
+                "progress/run": run,
+                "progress/epoch": epoch,
+                "progress/global_step": global_step,
+
+                # Best validation loss tracking
+                "best/val_loss": global_best_val_loss if valid_loss >= global_best_val_loss else valid_loss,
+            })
+
             result = (
                 train_loss,
                 valid_loss,
@@ -253,6 +336,25 @@ def run_gnn_baseline(
             if valid_loss < global_best_val_loss:
                 global_best_val_loss = valid_loss
                 best_state_dict = model.state_dict()
+                # Log best model checkpoint info
+                wandb.run.summary["best_val_loss"] = global_best_val_loss
+                wandb.run.summary["best_epoch"] = epoch
+                wandb.run.summary["best_run"] = run
+
+            # Early stopping logic
+            if valid_loss < best_val_loss_in_run:
+                best_val_loss_in_run = valid_loss
+                epochs_without_improvement = 0
+            else:
+                epochs_without_improvement += 1
+
+            if model_arguments.patience > 0 and epochs_without_improvement >= model_arguments.patience:
+                logging.info(
+                    f'Early stopping at epoch {epoch}. '
+                    f'No improvement for {model_arguments.patience} epochs. '
+                    f'Best val loss in run: {best_val_loss_in_run:.4f}'
+                )
+                break
 
         final_avg_preds.append(mean_across_lists(epoch_avg_preds))
         final_avg_targets.append(mean_across_lists(epoch_avg_targets))
@@ -264,24 +366,47 @@ def run_gnn_baseline(
     best_model_path = best_model_dir / 'best_model.pt'
     torch.save(best_state_dict, best_model_path)
     logging.info(f'Model: {model_arguments} weights saved to: {best_model_path}')
+
+    # Save model as wandb artifact
+    model_artifact = wandb.Artifact(
+        name=f"{model_arguments.model}-best-model",
+        type="model",
+        description=f"Best model checkpoint for {model_arguments.model}",
+    )
+    model_artifact.add_file(str(best_model_path))
+    wandb.log_artifact(model_artifact)
+
     logging.info('*** Statistics ***')
-    logging.info(logger.get_statistics())
-    logging.info(logger.get_avg_statistics())
-    logging.info(
-        logger.per_run_within_error(
-            preds=final_avg_preds, targets=final_avg_targets, percent=10
-        )
+    statistics = logger.get_statistics()
+    avg_statistics = logger.get_avg_statistics()
+    logging.info(statistics)
+    logging.info(avg_statistics)
+
+    # Log final statistics to wandb
+    error_10 = logger.per_run_within_error(
+        preds=final_avg_preds, targets=final_avg_targets, percent=10
     )
-    logging.info(
-        logger.per_run_within_error(
-            preds=final_avg_preds, targets=final_avg_targets, percent=5
-        )
+    error_5 = logger.per_run_within_error(
+        preds=final_avg_preds, targets=final_avg_targets, percent=5
     )
-    logging.info(
-        logger.per_run_within_error(
-            preds=final_avg_preds, targets=final_avg_targets, percent=1
-        )
+    error_1 = logger.per_run_within_error(
+        preds=final_avg_preds, targets=final_avg_targets, percent=1
     )
+
+    logging.info(error_10)
+    logging.info(error_5)
+    logging.info(error_1)
+
+    # Log summary statistics to wandb
+    wandb.run.summary.update({
+        "final/model": model_arguments.model,
+        "final/best_val_loss": global_best_val_loss,
+        "final/within_10pct_error": error_10,
+        "final/within_5pct_error": error_5,
+        "final/within_1pct_error": error_1,
+        "final/total_epochs": model_arguments.epochs * model_arguments.runs,
+        "final/total_runs": model_arguments.runs,
+    })
     logging.info('Constructing plots')
     plot_pred_target_distributions_bin_list(
         preds=final_avg_preds,

--- a/credipred/experiments/gnn_experiments/gnn_experiment.py
+++ b/credipred/experiments/gnn_experiments/gnn_experiment.py
@@ -287,38 +287,38 @@ def run_gnn_baseline(
                 gpu_memory_reserved = torch.cuda.memory_reserved(device) / 1e9  # GB
                 gpu_max_memory = torch.cuda.max_memory_allocated(device) / 1e9  # GB
 
-            wandb.log({
-                # Training metrics
-                "train/loss": train_loss,
-                "train/r2": train_r2,
-
-                # Validation metrics
-                "val/loss": valid_loss,
-                "val/r2": valid_r2,
-                "val/mean_baseline_loss": valid_mean_baseline_loss,
-
-                # Test metrics
-                "test/loss": test_loss,
-                "test/r2": test_r2,
-                "test/mean_baseline_loss": test_mean_baseline_loss,
-                "test/random_baseline_loss": test_random_baseline_loss,
-
-                # Learning rate
-                "train/learning_rate": current_lr,
-
-                # GPU metrics
-                "gpu/memory_allocated_gb": gpu_memory_allocated,
-                "gpu/memory_reserved_gb": gpu_memory_reserved,
-                "gpu/max_memory_allocated_gb": gpu_max_memory if torch.cuda.is_available() else 0,
-
-                # Progress tracking
-                "progress/run": run,
-                "progress/epoch": epoch,
-                "progress/global_step": global_step,
-
-                # Best validation loss tracking
-                "best/val_loss": global_best_val_loss if valid_loss >= global_best_val_loss else valid_loss,
-            })
+            wandb.log(
+                {
+                    # Training metrics
+                    'train/loss': train_loss,
+                    'train/r2': train_r2,
+                    # Validation metrics
+                    'val/loss': valid_loss,
+                    'val/r2': valid_r2,
+                    'val/mean_baseline_loss': valid_mean_baseline_loss,
+                    # Test metrics
+                    'test/loss': test_loss,
+                    'test/r2': test_r2,
+                    'test/mean_baseline_loss': test_mean_baseline_loss,
+                    'test/random_baseline_loss': test_random_baseline_loss,
+                    # Learning rate
+                    'train/learning_rate': current_lr,
+                    # GPU metrics
+                    'gpu/memory_allocated_gb': gpu_memory_allocated,
+                    'gpu/memory_reserved_gb': gpu_memory_reserved,
+                    'gpu/max_memory_allocated_gb': gpu_max_memory
+                    if torch.cuda.is_available()
+                    else 0,
+                    # Progress tracking
+                    'progress/run': run,
+                    'progress/epoch': epoch,
+                    'progress/global_step': global_step,
+                    # Best validation loss tracking
+                    'best/val_loss': global_best_val_loss
+                    if valid_loss >= global_best_val_loss
+                    else valid_loss,
+                }
+            )
 
             result = (
                 train_loss,
@@ -337,9 +337,9 @@ def run_gnn_baseline(
                 global_best_val_loss = valid_loss
                 best_state_dict = model.state_dict()
                 # Log best model checkpoint info
-                wandb.run.summary["best_val_loss"] = global_best_val_loss
-                wandb.run.summary["best_epoch"] = epoch
-                wandb.run.summary["best_run"] = run
+                wandb.run.summary['best_val_loss'] = global_best_val_loss
+                wandb.run.summary['best_epoch'] = epoch
+                wandb.run.summary['best_run'] = run
 
             # Early stopping logic
             if valid_loss < best_val_loss_in_run:
@@ -348,7 +348,10 @@ def run_gnn_baseline(
             else:
                 epochs_without_improvement += 1
 
-            if model_arguments.patience > 0 and epochs_without_improvement >= model_arguments.patience:
+            if (
+                model_arguments.patience > 0
+                and epochs_without_improvement >= model_arguments.patience
+            ):
                 logging.info(
                     f'Early stopping at epoch {epoch}. '
                     f'No improvement for {model_arguments.patience} epochs. '
@@ -369,9 +372,9 @@ def run_gnn_baseline(
 
     # Save model as wandb artifact
     model_artifact = wandb.Artifact(
-        name=f"{model_arguments.model}-best-model",
-        type="model",
-        description=f"Best model checkpoint for {model_arguments.model}",
+        name=f'{model_arguments.model}-best-model',
+        type='model',
+        description=f'Best model checkpoint for {model_arguments.model}',
     )
     model_artifact.add_file(str(best_model_path))
     wandb.log_artifact(model_artifact)
@@ -398,15 +401,17 @@ def run_gnn_baseline(
     logging.info(error_1)
 
     # Log summary statistics to wandb
-    wandb.run.summary.update({
-        "final/model": model_arguments.model,
-        "final/best_val_loss": global_best_val_loss,
-        "final/within_10pct_error": error_10,
-        "final/within_5pct_error": error_5,
-        "final/within_1pct_error": error_1,
-        "final/total_epochs": model_arguments.epochs * model_arguments.runs,
-        "final/total_runs": model_arguments.runs,
-    })
+    wandb.run.summary.update(
+        {
+            'final/model': model_arguments.model,
+            'final/best_val_loss': global_best_val_loss,
+            'final/within_10pct_error': error_10,
+            'final/within_5pct_error': error_5,
+            'final/within_1pct_error': error_1,
+            'final/total_epochs': model_arguments.epochs * model_arguments.runs,
+            'final/total_runs': model_arguments.runs,
+        }
+    )
     logging.info('Constructing plots')
     plot_pred_target_distributions_bin_list(
         preds=final_avg_preds,

--- a/credipred/experiments/gnn_experiments/main.py
+++ b/credipred/experiments/gnn_experiments/main.py
@@ -48,23 +48,26 @@ def main() -> None:
 
     # Initialize wandb with comprehensive config (offline mode - no API key required)
     wandb_run = wandb.init(
-        project="CrediPred-GNN",
-        name=f"{meta_args.target_col}-{os.path.basename(args.config_file).replace('.yaml', '')}",
+        project='CrediPred-GNN',
+        name=f'{meta_args.target_col}-{os.path.basename(args.config_file).replace(".yaml", "")}',
         config={
             # Meta arguments
-            "config_file": args.config_file,
-            "target_col": meta_args.target_col,
-            "node_file": meta_args.node_file,
-            "edge_file": meta_args.edge_file,
-            "global_seed": meta_args.global_seed,
-            "force_undirected": meta_args.force_undirected,
-            "encoder_dict": meta_args.encoder_dict,
+            'config_file': args.config_file,
+            'target_col': meta_args.target_col,
+            'node_file': meta_args.node_file,
+            'edge_file': meta_args.edge_file,
+            'global_seed': meta_args.global_seed,
+            'force_undirected': meta_args.force_undirected,
+            'encoder_dict': meta_args.encoder_dict,
         },
-        tags=[meta_args.target_col, os.path.basename(args.config_file).replace('.yaml', '')],
+        tags=[
+            meta_args.target_col,
+            os.path.basename(args.config_file).replace('.yaml', ''),
+        ],
         save_code=True,
-        mode="offline",
+        mode='offline',
     )
-    logging.info(f"WandB run initialized: {wandb_run.url}")
+    logging.info(f'WandB run initialized: {wandb_run.url}')
 
     encoder_classes: Dict[str, Encoder] = {
         'RNI': RNIEncoder(64),  # TODO: Set this a paramater
@@ -105,24 +108,27 @@ def main() -> None:
     for experiment, experiment_arg in experiment_args.exp_args.items():
         logging.info(f'\n**Running**: {experiment}')
         # Update wandb config with experiment-specific parameters
-        wandb.config.update({
-            f"experiment_{experiment}": {
-                "model": experiment_arg.model_args.model,
-                "num_layers": experiment_arg.model_args.num_layers,
-                "hidden_channels": experiment_arg.model_args.hidden_channels,
-                "num_neighbors": experiment_arg.model_args.num_neighbors,
-                "batch_size": experiment_arg.model_args.batch_size,
-                "dropout": experiment_arg.model_args.dropout,
-                "lr": experiment_arg.model_args.lr,
-                "epochs": experiment_arg.model_args.epochs,
-                "runs": experiment_arg.model_args.runs,
-                "gps_heads": experiment_arg.model_args.gps_heads,
-                "gps_attn_type": experiment_arg.model_args.gps_attn_type,
-                "gps_attn_dropout": experiment_arg.model_args.gps_attn_dropout,
-                "task_name": experiment_arg.data_args.task_name,
-                "is_regression": experiment_arg.data_args.is_regression,
-            }
-        }, allow_val_change=True)
+        wandb.config.update(
+            {
+                f'experiment_{experiment}': {
+                    'model': experiment_arg.model_args.model,
+                    'num_layers': experiment_arg.model_args.num_layers,
+                    'hidden_channels': experiment_arg.model_args.hidden_channels,
+                    'num_neighbors': experiment_arg.model_args.num_neighbors,
+                    'batch_size': experiment_arg.model_args.batch_size,
+                    'dropout': experiment_arg.model_args.dropout,
+                    'lr': experiment_arg.model_args.lr,
+                    'epochs': experiment_arg.model_args.epochs,
+                    'runs': experiment_arg.model_args.runs,
+                    'gps_heads': experiment_arg.model_args.gps_heads,
+                    'gps_attn_type': experiment_arg.model_args.gps_attn_type,
+                    'gps_attn_dropout': experiment_arg.model_args.gps_attn_dropout,
+                    'task_name': experiment_arg.data_args.task_name,
+                    'is_regression': experiment_arg.data_args.is_regression,
+                }
+            },
+            allow_val_change=True,
+        )
         run_gnn_baseline(
             experiment_arg.data_args,
             experiment_arg.model_args,
@@ -139,7 +145,7 @@ def main() -> None:
 
     # Finish wandb run
     wandb.finish()
-    logging.info("WandB run finished.")
+    logging.info('WandB run finished.')
 
 
 if __name__ == '__main__':

--- a/credipred/experiments/gnn_experiments/main.py
+++ b/credipred/experiments/gnn_experiments/main.py
@@ -1,6 +1,9 @@
 import argparse
 import logging
+import os
 from typing import Dict, cast
+
+import wandb
 
 from credipred.dataset.temporal_dataset import TemporalDataset
 from credipred.encoders.categorical_encoder import CategoricalEncoder
@@ -43,6 +46,26 @@ def main() -> None:
     setup_logging(meta_args.log_file_path)
     seed_everything(meta_args.global_seed)
 
+    # Initialize wandb with comprehensive config (offline mode - no API key required)
+    wandb_run = wandb.init(
+        project="CrediPred-GNN",
+        name=f"{meta_args.target_col}-{os.path.basename(args.config_file).replace('.yaml', '')}",
+        config={
+            # Meta arguments
+            "config_file": args.config_file,
+            "target_col": meta_args.target_col,
+            "node_file": meta_args.node_file,
+            "edge_file": meta_args.edge_file,
+            "global_seed": meta_args.global_seed,
+            "force_undirected": meta_args.force_undirected,
+            "encoder_dict": meta_args.encoder_dict,
+        },
+        tags=[meta_args.target_col, os.path.basename(args.config_file).replace('.yaml', '')],
+        save_code=True,
+        mode="offline",
+    )
+    logging.info(f"WandB run initialized: {wandb_run.url}")
+
     encoder_classes: Dict[str, Encoder] = {
         'RNI': RNIEncoder(64),  # TODO: Set this a paramater
         'ZERO': ZeroEncoder(64),
@@ -74,11 +97,32 @@ def main() -> None:
         encoding=encoding_dict,
         seed=meta_args.global_seed,
         processed_dir=cast(str, meta_args.processed_location),
+        embedding_index_file=meta_args.embedding_index_file,
+        embedding_folder=meta_args.embedding_folder,
     )  # Map to .to_cpu()
     logging.info('In-Memory Dataset loaded.')
 
     for experiment, experiment_arg in experiment_args.exp_args.items():
         logging.info(f'\n**Running**: {experiment}')
+        # Update wandb config with experiment-specific parameters
+        wandb.config.update({
+            f"experiment_{experiment}": {
+                "model": experiment_arg.model_args.model,
+                "num_layers": experiment_arg.model_args.num_layers,
+                "hidden_channels": experiment_arg.model_args.hidden_channels,
+                "num_neighbors": experiment_arg.model_args.num_neighbors,
+                "batch_size": experiment_arg.model_args.batch_size,
+                "dropout": experiment_arg.model_args.dropout,
+                "lr": experiment_arg.model_args.lr,
+                "epochs": experiment_arg.model_args.epochs,
+                "runs": experiment_arg.model_args.runs,
+                "gps_heads": experiment_arg.model_args.gps_heads,
+                "gps_attn_type": experiment_arg.model_args.gps_attn_type,
+                "gps_attn_dropout": experiment_arg.model_args.gps_attn_dropout,
+                "task_name": experiment_arg.data_args.task_name,
+                "is_regression": experiment_arg.data_args.is_regression,
+            }
+        }, allow_val_change=True)
         run_gnn_baseline(
             experiment_arg.data_args,
             experiment_arg.model_args,
@@ -92,6 +136,10 @@ def main() -> None:
     plot_metric_per_encoder(results)
     logging.info('Constructing Plots, model per-encoder')
     plot_model_per_encoder(results)
+
+    # Finish wandb run
+    wandb.finish()
+    logging.info("WandB run finished.")
 
 
 if __name__ == '__main__':

--- a/credipred/gnn/model.py
+++ b/credipred/gnn/model.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import torch
 from torch import Tensor, nn
@@ -9,6 +9,8 @@ from credipred.gnn.modules import (
     GATv2Module,
     GCNModule,
     GINModule,
+    GraphGPSModule,
+    GraphGPSResidualWrapper,
     NodePredictor,
     ResidualModuleWrapper,
     SAGEModule,
@@ -25,6 +27,7 @@ class Model(torch.nn.Module):
         'GATv2': GATv2Module,
         'GIN': GINModule,
         'FF': FFModule,
+        'GPS': GraphGPSModule,
     }
     normalization_map: dict[str, NormalizationType] = {
         'none': torch.nn.Identity,
@@ -41,9 +44,15 @@ class Model(torch.nn.Module):
         out_channels: int,
         num_layers: int,
         dropout: float,
+        # GraphGPS specific parameters
+        gps_heads: int = 4,
+        gps_attn_type: str = 'multihead',
+        gps_attn_kwargs: Optional[Dict[str, Any]] = None,
+        gps_local_mpnn: str = 'gin',
     ):
         super().__init__()
         self.model_name = model_name
+        self.is_gps = model_name == 'GPS'
         normalization_cls = self.normalization_map[normalization]
         self.input_linear = nn.Linear(
             in_features=in_channels, out_features=hidden_channels
@@ -54,12 +63,24 @@ class Model(torch.nn.Module):
         self.re_modules = nn.ModuleList()
 
         for _ in range(num_layers):
-            residual_module = ResidualModuleWrapper(
-                module=self.modules[model_name],
-                normalization=normalization_cls,
-                dim=hidden_channels,
-                dropout=dropout,
-            )
+            if self.is_gps:
+                # Use GraphGPS-specific residual wrapper
+                residual_module = GraphGPSResidualWrapper(
+                    normalization=normalization_cls,
+                    dim=hidden_channels,
+                    dropout=dropout,
+                    heads=gps_heads,
+                    attn_type=gps_attn_type,
+                    attn_kwargs=gps_attn_kwargs,
+                    local_mpnn_type=gps_local_mpnn,
+                )
+            else:
+                residual_module = ResidualModuleWrapper(
+                    module=self.modules[model_name],
+                    normalization=normalization_cls,
+                    dim=hidden_channels,
+                    dropout=dropout,
+                )
             self.re_modules.append(residual_module)
 
         self.output_normalization = normalization_cls(hidden_channels)
@@ -68,13 +89,21 @@ class Model(torch.nn.Module):
         )
         self.node_predictor = NodePredictor(in_dim=out_channels, out_dim=1)
 
-    def forward(self, x: Tensor, edge_index: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor | None = None,
+        batch: Tensor | None = None,
+    ) -> Tensor:
         x = self.input_linear(x)
         x = self.dropout(x)
         x = self.act(x)
 
         for re_module in self.re_modules:
-            if edge_index is not None:
+            if self.is_gps:
+                # GraphGPS needs batch tensor for global attention
+                x = re_module(x, edge_index, batch)
+            elif edge_index is not None:
                 x = re_module(x, edge_index)
             else:
                 x = re_module(x)
@@ -84,13 +113,20 @@ class Model(torch.nn.Module):
         x = self.node_predictor(x)
         return x
 
-    def get_embeddings(self, x: Tensor, edge_index: Tensor | None = None) -> Tensor:
+    def get_embeddings(
+        self,
+        x: Tensor,
+        edge_index: Tensor | None = None,
+        batch: Tensor | None = None,
+    ) -> Tensor:
         x = self.input_linear(x)
         x = self.dropout(x)
         x = self.act(x)
 
         for re_module in self.re_modules:
-            if edge_index is not None:
+            if self.is_gps:
+                x = re_module(x, edge_index, batch)
+            elif edge_index is not None:
                 x = re_module(x, edge_index)
             else:
                 x = re_module(x)

--- a/credipred/gnn/modules.py
+++ b/credipred/gnn/modules.py
@@ -219,7 +219,7 @@ class GraphGPSModule(nn.Module):
             local_mpnn = GATConv(dim, dim, heads=1, concat=False)
         else:
             raise ValueError(
-                f"Unknown local_mpnn_type: {local_mpnn_type}. "
+                f'Unknown local_mpnn_type: {local_mpnn_type}. '
                 "Choices: 'gin', 'gatedgcn', 'gat'."
             )
 

--- a/credipred/gnn/modules.py
+++ b/credipred/gnn/modules.py
@@ -1,7 +1,15 @@
-from typing import Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 from torch import Tensor, nn
-from torch_geometric.nn import GATConv, GATv2Conv, GCNConv, GINConv, SAGEConv
+from torch_geometric.nn import (
+    GATConv,
+    GATv2Conv,
+    GCNConv,
+    GINConv,
+    GPSConv,
+    ResGatedGraphConv,
+    SAGEConv,
+)
 
 NormalizationType = Union[Type[nn.Identity], Type[nn.LayerNorm], Type[nn.BatchNorm1d]]
 
@@ -168,4 +176,114 @@ class FFModule(nn.Module):
 
     def forward(self, x: Tensor, edge_index: Tensor) -> Tensor:
         x = self.feed_forward_module(x)
+        return x
+
+
+class GraphGPSModule(nn.Module):
+    """GraphGPS layer combining local message passing with global attention.
+
+    This module wraps PyTorch Geometric's GPSConv which combines:
+    - Local MPNN (message passing neural network): GIN, GatedGCN, or GAT
+    - Global attention mechanism (multihead or performer)
+
+    Reference: https://arxiv.org/abs/2205.12454
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        dropout: float,
+        heads: int = 4,
+        attn_type: str = 'multihead',
+        attn_kwargs: Optional[Dict[str, Any]] = None,
+        local_mpnn_type: str = 'gin',
+    ):
+        super().__init__()
+        if attn_kwargs is None:
+            attn_kwargs = {'dropout': dropout}
+
+        # Select local MPNN based on type
+        if local_mpnn_type == 'gin':
+            # GIN with MLP (original GPS default)
+            local_nn = nn.Sequential(
+                nn.Linear(dim, dim),
+                nn.ReLU(),
+                nn.Linear(dim, dim),
+            )
+            local_mpnn = GINConv(local_nn)
+        elif local_mpnn_type == 'gatedgcn':
+            # GatedGCN - recommended by GraphGPS paper
+            local_mpnn = ResGatedGraphConv(dim, dim)
+        elif local_mpnn_type == 'gat':
+            # GAT - local attention mechanism
+            local_mpnn = GATConv(dim, dim, heads=1, concat=False)
+        else:
+            raise ValueError(
+                f"Unknown local_mpnn_type: {local_mpnn_type}. "
+                "Choices: 'gin', 'gatedgcn', 'gat'."
+            )
+
+        # GPSConv combines local MPNN + global attention
+        self.conv = GPSConv(
+            channels=dim,
+            conv=local_mpnn,
+            heads=heads,
+            attn_type=attn_type,
+            attn_kwargs=attn_kwargs,
+            dropout=dropout,
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        batch: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Forward pass with optional batch tensor for global attention.
+
+        Args:
+            x: Node features [num_nodes, dim]
+            edge_index: Edge indices [2, num_edges]
+            batch: Batch assignment for each node [num_nodes] (optional)
+
+        Returns:
+            Updated node features [num_nodes, dim]
+        """
+        x = self.conv(x, edge_index, batch=batch)
+        return x
+
+
+class GraphGPSResidualWrapper(nn.Module):
+    """Residual wrapper specifically for GraphGPS that handles batch parameter."""
+
+    def __init__(
+        self,
+        normalization: NormalizationType,
+        dim: int,
+        dropout: float,
+        heads: int = 4,
+        attn_type: str = 'multihead',
+        attn_kwargs: Optional[Dict[str, Any]] = None,
+        local_mpnn_type: str = 'gin',
+    ):
+        super().__init__()
+        self.normalization = normalization(dim)
+        self.module = GraphGPSModule(
+            dim=dim,
+            dropout=dropout,
+            heads=heads,
+            attn_type=attn_type,
+            attn_kwargs=attn_kwargs,
+            local_mpnn_type=local_mpnn_type,
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        edge_index: Tensor,
+        batch: Optional[Tensor] = None,
+    ) -> Tensor:
+        x_res = self.normalization(x)
+        x_res = self.module(x_res, edge_index, batch)
+        x = x + x_res
         return x

--- a/credipred/utils/args.py
+++ b/credipred/utils/args.py
@@ -89,6 +89,14 @@ class MetaArguments:
             'help': 'Node encoder dictionary defines which column is encoded by which encoder. Key: column, Value: Encoder'
         },
     )
+    embedding_index_file: Optional[str] = field(
+        default=None,
+        metadata={'help': 'Path to the domain-to-embedding-file index pickle for PRE encoder.'},
+    )
+    embedding_folder: Optional[str] = field(
+        default=None,
+        metadata={'help': 'Path to the folder containing embedding pickle files for PRE encoder.'},
+    )
     global_seed: int = field(
         default=1337,
         metadata={'help': 'Random seed to use for reproducibiility.'},
@@ -117,6 +125,12 @@ class MetaArguments:
         self.target_file = resolve_paths(self.target_file)
         self.database_folder = resolve_paths(self.database_folder)
         self.processed_location = resolve_paths(self.processed_location)
+
+        # Resolve embedding paths if provided
+        if self.embedding_index_file is not None:
+            self.embedding_index_file = resolve_paths(self.embedding_index_file)
+        if self.embedding_folder is not None:
+            self.embedding_folder = resolve_paths(self.embedding_folder)
 
         if self.log_file_path is not None:
             self.log_file_path = str(get_root_dir() / self.log_file_path)
@@ -177,12 +191,43 @@ class ModelArguments:
     )
     dropout: float = field(default=0.1, metadata={'help': 'Dropout value.'})
     lr: float = field(default=0.001, metadata={'help': 'Learning Rate.'})
+    weight_decay: float = field(
+        default=0.0, metadata={'help': 'Weight decay (L2 regularization) for optimizer.'}
+    )
     epochs: int = field(default=500, metadata={'help': 'Number of epochs.'})
+    patience: int = field(
+        default=0,
+        metadata={
+            'help': 'Early stopping patience. 0 means no early stopping. '
+            'Training stops if validation loss does not improve for this many epochs.'
+        },
+    )
     runs: int = field(default=100, metadata={'help': 'Number of trials.'})
     use_cuda: bool = field(default=True, metadata={'help': 'Whether to use cuda.'})
     device: int = field(default=0, metadata={'help': 'Device to be used.'})
     log_steps: int = field(
         default=50, metadata={'help': 'Step mod epoch to print logger.'}
+    )
+    # GraphGPS specific parameters
+    gps_heads: int = field(
+        default=4,
+        metadata={'help': 'Number of attention heads for GraphGPS global attention.'},
+    )
+    gps_attn_type: str = field(
+        default='multihead',
+        metadata={
+            'help': "Attention type for GraphGPS. Choices: 'multihead' or 'performer'."
+        },
+    )
+    gps_attn_dropout: float = field(
+        default=0.1,
+        metadata={'help': 'Dropout rate for GraphGPS attention.'},
+    )
+    gps_local_mpnn: str = field(
+        default='gin',
+        metadata={
+            'help': "Local MPNN type for GraphGPS. Choices: 'gin', 'gatedgcn', 'gat'."
+        },
     )
 
 

--- a/credipred/utils/args.py
+++ b/credipred/utils/args.py
@@ -91,11 +91,15 @@ class MetaArguments:
     )
     embedding_index_file: Optional[str] = field(
         default=None,
-        metadata={'help': 'Path to the domain-to-embedding-file index pickle for PRE encoder.'},
+        metadata={
+            'help': 'Path to the domain-to-embedding-file index pickle for PRE encoder.'
+        },
     )
     embedding_folder: Optional[str] = field(
         default=None,
-        metadata={'help': 'Path to the folder containing embedding pickle files for PRE encoder.'},
+        metadata={
+            'help': 'Path to the folder containing embedding pickle files for PRE encoder.'
+        },
     )
     global_seed: int = field(
         default=1337,
@@ -192,7 +196,8 @@ class ModelArguments:
     dropout: float = field(default=0.1, metadata={'help': 'Dropout value.'})
     lr: float = field(default=0.001, metadata={'help': 'Learning Rate.'})
     weight_decay: float = field(
-        default=0.0, metadata={'help': 'Weight decay (L2 regularization) for optimizer.'}
+        default=0.0,
+        metadata={'help': 'Weight decay (L2 regularization) for optimizer.'},
     )
     epochs: int = field(default=500, metadata={'help': 'Number of epochs.'})
     patience: int = field(

--- a/credipred/utils/logger.py
+++ b/credipred/utils/logger.py
@@ -90,10 +90,10 @@ class Logger(object):
             lines.append(f'  Final Train Loss: {result[argmin, 0]:.4f}')
             lines.append(f'   Final Test Loss: {result[argmin, 2]:.4f}')
         else:
-            result = torch.tensor(self.results)
-
+            # Handle variable-length runs (due to early stopping)
             best_results = []
-            for r in result:
+            for run_results in self.results:
+                r = torch.tensor(run_results)
                 train = r[:, 0].min().item()
                 valid = r[:, 1].min().item()
                 test = r[:, 2].min().item()
@@ -168,7 +168,11 @@ class Logger(object):
                 Multi-line formatted summary string.
         """
         lines = []
-        results_tensor = torch.tensor(self.results)  # shape: (runs, epochs, 3)
+        # Handle variable-length runs (due to early stopping)
+        # Truncate to minimum length across all runs
+        min_epochs = min(len(run) for run in self.results)
+        truncated_results = [run[:min_epochs] for run in self.results]
+        results_tensor = torch.tensor(truncated_results)  # shape: (runs, epochs, 4)
         avg = results_tensor.mean(dim=0)  # shape: (epochs, 3)
         std = results_tensor.std(dim=0)  # shape: (epochs, 3)
 

--- a/credipred/utils/plot.py
+++ b/credipred/utils/plot.py
@@ -78,9 +78,9 @@ def plot_pred_target_distributions_bin_list(
     plt.rc('font', size=13)
     plt.xticks(np.arange(0, 1.1, 0.2))
     plt.yticks(np.arange(0, y_max + 200, 200))
-    plt.yscale('log')
+    # plt.yscale('log')  # 注释掉后使用普通线性计数
     plt.xlabel('Score')
-    plt.ylabel('Frequency')
+    plt.ylabel('Count')
     plt.legend()
     plt.tight_layout()
     plt.savefig(save_path, bbox_inches='tight', pad_inches=0.1)

--- a/credipred/utils/readers.py
+++ b/credipred/utils/readers.py
@@ -203,7 +203,7 @@ def load_node_csv(
                 if embedding_index_file is None or embedding_folder is None:
                     raise ValueError(
                         "PRE encoder requires 'embedding_index_file' and 'embedding_folder' "
-                        "to be specified in the config."
+                        'to be specified in the config.'
                     )
                 xs.append(
                     encoder(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "cloudscraper>=1.2.71",
     "BeautifulSoup4>=4.13.0",
     "jsonpath-ng>=1.7.0",
+    "wandb>=0.18.0",
 ]
 
 [tool.flit.module]

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,14 @@ version = 1
 revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version < '3.10'",
-    "python_full_version == '3.10.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version >= '3.12'",
+    "python_full_version < '3.10' and sys_platform == 'linux'",
+    "python_full_version < '3.10' and sys_platform != 'linux'",
+    "python_full_version == '3.10.*' and sys_platform == 'linux'",
+    "python_full_version == '3.10.*' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.12' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and sys_platform != 'linux'",
 ]
 
 [[package]]
@@ -131,6 +135,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -372,6 +385,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+]
+
+[[package]]
 name = "cloudscraper"
 version = "1.2.71"
 source = { registry = "https://pypi.org/simple" }
@@ -502,6 +527,7 @@ dependencies = [
     { name = "torch-geometric" },
     { name = "torcheval" },
     { name = "ujson" },
+    { name = "wandb" },
     { name = "warcio" },
 ]
 
@@ -542,6 +568,7 @@ requires-dist = [
     { name = "torch-geometric", specifier = ">=2.6.1" },
     { name = "torcheval", specifier = ">=0.0.7" },
     { name = "ujson", specifier = ">=5.10.0" },
+    { name = "wandb", specifier = ">=0.18.0" },
     { name = "warcio", specifier = ">=1.7.5" },
 ]
 
@@ -616,6 +643,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "eval-type-backport"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a3/cafafb4558fd638aadfe4121dc6cefb8d743368c085acb2f521df0f3d9d7/eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed", size = 9445, upload-time = "2025-12-02T11:51:42.987Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/22/fdc2e30d43ff853720042fa15baa3e6122722be1a7950a98233ebb55cd71/eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8", size = 6063, upload-time = "2025-12-02T11:51:41.665Z" },
 ]
 
 [[package]]
@@ -815,6 +851,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -2195,6 +2256,23 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/b8/cda15d9d46d03d4aa3a67cb6bffe05173440ccf86a9541afaf7ac59a1b6b/protobuf-6.33.4.tar.gz", hash = "sha256:dc2e61bca3b10470c1912d166fe0af67bfc20eb55971dcef8dfa48ce14f0ed91", size = 444346, upload-time = "2026-01-12T18:33:40.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/be/24ef9f3095bacdf95b458543334d0c4908ccdaee5130420bf064492c325f/protobuf-6.33.4-cp310-abi3-win32.whl", hash = "sha256:918966612c8232fc6c24c78e1cd89784307f5814ad7506c308ee3cf86662850d", size = 425612, upload-time = "2026-01-12T18:33:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ad/e5693e1974a28869e7cd244302911955c1cebc0161eb32dfa2b25b6e96f0/protobuf-6.33.4-cp310-abi3-win_amd64.whl", hash = "sha256:8f11ffae31ec67fc2554c2ef891dcb561dae9a2a3ed941f9e134c2db06657dbc", size = 436962, upload-time = "2026-01-12T18:33:31.345Z" },
+    { url = "https://files.pythonhosted.org/packages/66/15/6ee23553b6bfd82670207ead921f4d8ef14c107e5e11443b04caeb5ab5ec/protobuf-6.33.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:2fe67f6c014c84f655ee06f6f66213f9254b3a8b6bda6cda0ccd4232c73c06f0", size = 427612, upload-time = "2026-01-12T18:33:32.646Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/48/d301907ce6d0db75f959ca74f44b475a9caa8fcba102d098d3c3dd0f2d3f/protobuf-6.33.4-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:757c978f82e74d75cba88eddec479df9b99a42b31193313b75e492c06a51764e", size = 324484, upload-time = "2026-01-12T18:33:33.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1c/e53078d3f7fe710572ab2dcffd993e1e3b438ae71cfc031b71bae44fcb2d/protobuf-6.33.4-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c7c64f259c618f0bef7bee042075e390debbf9682334be2b67408ec7c1c09ee6", size = 339256, upload-time = "2026-01-12T18:33:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8e/971c0edd084914f7ee7c23aa70ba89e8903918adca179319ee94403701d5/protobuf-6.33.4-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:3df850c2f8db9934de4cf8f9152f8dc2558f49f298f37f90c517e8e5c84c30e9", size = 323311, upload-time = "2026-01-12T18:33:36.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/5c6cda3fbdde7473edcfd4c93a698a3021ffdcc92f3c101203a93bfd9c04/protobuf-6.33.4-cp39-cp39-win32.whl", hash = "sha256:955478a89559fa4568f5a81dce77260eabc5c686f9e8366219ebd30debf06aa6", size = 425734, upload-time = "2026-01-12T18:33:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/a128b3eb55954074074bdba124003e64d255314a12888fd41faecc458798/protobuf-6.33.4-cp39-cp39-win_amd64.whl", hash = "sha256:0f12ddbf96912690c3582f9dffb55530ef32015ad8e678cd494312bd78314c4f", size = 436984, upload-time = "2026-01-12T18:33:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b1/1dc83c2c661b4c62d56cc081706ee33a4fc2835bd90f965baa2663ef7676/protobuf-6.33.4-py3-none-any.whl", hash = "sha256:1fe3730068fcf2e595816a6c34fe66eeedd37d51d0400b72fabc848811fdc1bc", size = 170532, upload-time = "2026-01-12T18:33:39.199Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2243,6 +2321,152 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/54/db/160dffb57ed9a3705c4cbcbff0ac03bdae45f1ca7d58ab74645550df3fbd/pydantic_core-2.41.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8bfeaf8735be79f225f3fefab7f941c712aaca36f1128c9d7e2352ee1aa87bdf", size = 2107999, upload-time = "2025-11-04T13:42:03.885Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/7d/88e7de946f60d9263cc84819f32513520b85c0f8322f9b8f6e4afc938383/pydantic_core-2.41.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346285d28e4c8017da95144c7f3acd42740d637ff41946af5ce6e5e420502dd5", size = 1929745, upload-time = "2025-11-04T13:42:06.075Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c2/aef51e5b283780e85e99ff19db0f05842d2d4a8a8cd15e63b0280029b08f/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75dafbf87d6276ddc5b2bf6fae5254e3d0876b626eb24969a574fff9149ee5d", size = 1920220, upload-time = "2025-11-04T13:42:08.457Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/97/492ab10f9ac8695cd76b2fdb24e9e61f394051df71594e9bcc891c9f586e/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b93a4d08587e2b7e7882de461e82b6ed76d9026ce91ca7915e740ecc7855f60", size = 2067296, upload-time = "2025-11-04T13:42:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/23/984149650e5269c59a2a4c41d234a9570adc68ab29981825cfaf4cfad8f4/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8465ab91a4bd96d36dde3263f06caa6a8a6019e4113f24dc753d79a8b3a3f82", size = 2231548, upload-time = "2025-11-04T13:42:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0c/85bcbb885b9732c28bec67a222dbed5ed2d77baee1f8bba2002e8cd00c5c/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:299e0a22e7ae2b85c1a57f104538b2656e8ab1873511fd718a1c1c6f149b77b5", size = 2362571, upload-time = "2025-11-04T13:42:16.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/4a/412d2048be12c334003e9b823a3fa3d038e46cc2d64dd8aab50b31b65499/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:707625ef0983fcfb461acfaf14de2067c5942c6bb0f3b4c99158bed6fedd3cf3", size = 2068175, upload-time = "2025-11-04T13:42:18.911Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f4/c58b6a776b502d0a5540ad02e232514285513572060f0d78f7832ca3c98b/pydantic_core-2.41.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425", size = 2177203, upload-time = "2025-11-04T13:42:22.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ae/f06ea4c7e7a9eead3d165e7623cd2ea0cb788e277e4f935af63fc98fa4e6/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0384e2e1021894b1ff5a786dbf94771e2986ebe2869533874d7e43bc79c6f504", size = 2148191, upload-time = "2025-11-04T13:42:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/57/25a11dcdc656bf5f8b05902c3c2934ac3ea296257cc4a3f79a6319e61856/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:f0cd744688278965817fd0839c4a4116add48d23890d468bc436f78beb28abf5", size = 2343907, upload-time = "2025-11-04T13:42:27.683Z" },
+    { url = "https://files.pythonhosted.org/packages/96/82/e33d5f4933d7a03327c0c43c65d575e5919d4974ffc026bc917a5f7b9f61/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:753e230374206729bf0a807954bcc6c150d3743928a73faffee51ac6557a03c3", size = 2322174, upload-time = "2025-11-04T13:42:30.776Z" },
+    { url = "https://files.pythonhosted.org/packages/81/45/4091be67ce9f469e81656f880f3506f6a5624121ec5eb3eab37d7581897d/pydantic_core-2.41.5-cp39-cp39-win32.whl", hash = "sha256:873e0d5b4fb9b89ef7c2d2a963ea7d02879d9da0da8d9d4933dee8ee86a8b460", size = 1990353, upload-time = "2025-11-04T13:42:33.111Z" },
+    { url = "https://files.pythonhosted.org/packages/44/8a/a98aede18db6e9cd5d66bcacd8a409fcf8134204cdede2e7de35c5a2c5ef/pydantic_core-2.41.5-cp39-cp39-win_amd64.whl", hash = "sha256:e4f4a984405e91527a0d62649ee21138f8e3d0ef103be488c1dc11a80d7f184b", size = 2015698, upload-time = "2025-11-04T13:42:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
 ]
 
 [[package]]
@@ -2847,6 +3071,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/9f/094bbb6be5cf218ab6712c6528310687f3d3fe8818249fcfe1d74192f7c5/sentry_sdk-2.51.0.tar.gz", hash = "sha256:b89d64577075fd8c13088bc3609a2ce77a154e5beb8cba7cc16560b0539df4f7", size = 407447, upload-time = "2026-01-28T10:29:50.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/da/df379404d484ca9dede4ad8abead5de828cdcff35623cd44f0351cf6869c/sentry_sdk-2.51.0-py2.py3-none-any.whl", hash = "sha256:e21016d318a097c2b617bb980afd9fc737e1efc55f9b4f0cdc819982c9717d5f", size = 431426, upload-time = "2026-01-28T10:29:48.868Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2862,6 +3099,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
 ]
 
 [[package]]
@@ -3169,6 +3415,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3268,6 +3526,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/60/4f20960df6c7b363a18a55ab034c8f2bcd5d9770d1f94f9370ec104c1855/virtualenv-20.33.1.tar.gz", hash = "sha256:1b44478d9e261b3fb8baa5e74a0ca3bc0e05f21aa36167bf9cbf850e542765b8", size = 6082160, upload-time = "2025-08-05T16:10:55.605Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/ff/ded57ac5ff40a09e6e198550bab075d780941e0b0f83cbeabd087c59383a/virtualenv-20.33.1-py3-none-any.whl", hash = "sha256:07c19bc66c11acab6a5958b815cbcee30891cd1c2ccf53785a28651a0d8d8a67", size = 6060362, upload-time = "2025-08-05T16:10:52.81Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7e/aad6e943012ea4d88f3a037f1a5a7c6898263c60fbef8c9cdb95a8ff9fd9/wandb-0.24.0.tar.gz", hash = "sha256:4715a243b3d460b6434b9562e935dfd9dfdf5d6e428cfb4c3e7ce4fd44460ab3", size = 44197947, upload-time = "2026-01-13T22:59:59.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/8a/efec186dcc5dcf3c806040e3f33e58997878b2d30b87aa02b26f046858b6/wandb-0.24.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:aa9777398ff4b0f04c41359f7d1b95b5d656cb12c37c63903666799212e50299", size = 21464901, upload-time = "2026-01-13T22:59:31.86Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/84/fadf0d5f1d86c3ba662d2b33a15d2b1f08ff1e4e196c77e455f028b0fda2/wandb-0.24.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:0423fbd58c3926949724feae8aab89d20c68846f9f4f596b80f9ffe1fc298130", size = 22697817, upload-time = "2026-01-13T22:59:35.267Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5f/e3124e68d02b30c62856175ce714e07904730be06eecb00f66bb1a59aacf/wandb-0.24.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2b25fc0c123daac97ed32912ac55642c65013cc6e3a898e88ca2d917fc8eadc0", size = 21118798, upload-time = "2026-01-13T22:59:38.453Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a1/8d68a914c030e897c306c876d47c73aa5d9ca72be608971290d3a5749570/wandb-0.24.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9485344b4667944b5b77294185bae8469cfa4074869bec0e74f54f8492234cc2", size = 22849954, upload-time = "2026-01-13T22:59:41.265Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/3e68841a4282a4fb6a8935534e6064acc6c9708e8fb76953ec73bbc72a5e/wandb-0.24.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:51b2b9a9d7d6b35640f12a46a48814fd4516807ad44f586b819ed6560f8de1fd", size = 21160339, upload-time = "2026-01-13T22:59:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e5/d851868ce5b4b437a7cc90405979cd83809790e4e2a2f1e454f63f116e52/wandb-0.24.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:11f7e7841f31eff82c82a677988889ad3aa684c6de61ff82145333b5214ec860", size = 22936978, upload-time = "2026-01-13T22:59:46.911Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/34/43b7f18870051047ce6fe18e7eb24ba7ebdc71663a8f1c58e31e855eb8ac/wandb-0.24.0-py3-none-win32.whl", hash = "sha256:42af348998b00d4309ae790c5374040ac6cc353ab21567f4e29c98c9376dee8e", size = 22118243, upload-time = "2026-01-13T22:59:49.555Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/92/909c81173cf1399111f57f9ca5399a8f165607b024e406e080178c878f70/wandb-0.24.0-py3-none-win_amd64.whl", hash = "sha256:32604eddcd362e1ed4a2e2ce5f3a239369c4a193af223f3e66603481ac91f336", size = 22118246, upload-time = "2026-01-13T22:59:52.126Z" },
+    { url = "https://files.pythonhosted.org/packages/87/85/a845aefd9c2285f98261fa6ffa0a14466366c1ac106d35bc84b654c0ad7f/wandb-0.24.0-py3-none-win_arm64.whl", hash = "sha256:e0f2367552abfca21b0f3a03405fbf48f1e14de9846e70f73c6af5da57afd8ef", size = 20077678, upload-time = "2026-01-13T22:59:56.112Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add GraphGPS model with configurable attention types (performer, multihead)
- Add GPS-specific parameters (gps_heads, gps_attn_type, gps_local_mpnn)
- Add get_prediction_target_distributions.py support GPS model weights
- Add gps_dec.yaml config for dec2024 dataset experiments
- Add Wandb in training