### PR TITLE
Add predictor type variants for NodePredictor

### DIFF
--- a/configs/gnn/gat_leaky_sigmoid.yaml
+++ b/configs/gnn/gat_leaky_sigmoid.yaml
@@ -1,0 +1,43 @@
+MetaArguments:
+  log_file_path: "gat_leaky_sigmoid.log"
+  node_file: "data/CrediBench/dec2024/vertices.csv"
+  edge_file: "data/CrediBench/dec2024/edges.csv"
+  target_file: "data/CrediBench/dec2024/targets.csv"
+  processed_location: "data/CrediBench/dec2024/processed_dir/pc1"
+  weights_directory: "data/weights_leaky_sigmoid/"
+  database_folder: "data/CrediBench/dec2024/"
+
+  target_col: "pc1"
+  target_index_name: 'nid'
+  target_index_col: 0
+  edge_src_col: "src"
+  edge_dst_col: "dst"
+  index_col: 0
+  encoder_dict:
+    pre: PRE
+  embedding_index_file: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m/dec2024_wetcontent_domains_index.pkl"
+  embedding_folder: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m"
+  is_scratch_location: false
+  global_seed: 42
+
+
+ExperimentArguments:
+  exp_args:
+    GAT_leaky_sigmoid:
+      model_args:
+        model: "GAT"
+        num_layers: 3
+        hidden_channels: 256
+        num_neighbors: [30, 30, 30]
+        batch_size: 1024
+        dropout: 0.1
+        lr: 0.001
+        epochs: 100
+        runs: 1
+        device: 0
+        log_steps: 10
+        predictor_type: "leaky_sigmoid"
+      data_args:
+        task_name: "node-regression"
+        is_regression: true
+        num_test_shards: 2

--- a/configs/gnn/gat_no_sigmoid.yaml
+++ b/configs/gnn/gat_no_sigmoid.yaml
@@ -1,0 +1,43 @@
+MetaArguments:
+  log_file_path: "gat_no_sigmoid.log"
+  node_file: "data/CrediBench/dec2024/vertices.csv"
+  edge_file: "data/CrediBench/dec2024/edges.csv"
+  target_file: "data/CrediBench/dec2024/targets.csv"
+  processed_location: "data/CrediBench/dec2024/processed_dir/pc1"
+  weights_directory: "data/weights_no_sigmoid/"
+  database_folder: "data/CrediBench/dec2024/"
+
+  target_col: "pc1"
+  target_index_name: 'nid'
+  target_index_col: 0
+  edge_src_col: "src"
+  edge_dst_col: "dst"
+  index_col: 0
+  encoder_dict:
+    pre: PRE
+  embedding_index_file: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m/dec2024_wetcontent_domains_index.pkl"
+  embedding_folder: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m"
+  is_scratch_location: false
+  global_seed: 42
+
+
+ExperimentArguments:
+  exp_args:
+    GAT_no_sigmoid:
+      model_args:
+        model: "GAT"
+        num_layers: 3
+        hidden_channels: 256
+        num_neighbors: [30, 30, 30]
+        batch_size: 1024
+        dropout: 0.1
+        lr: 0.001
+        epochs: 100
+        runs: 1
+        device: 0
+        log_steps: 10
+        predictor_type: "no_sigmoid"
+      data_args:
+        task_name: "node-regression"
+        is_regression: true
+        num_test_shards: 2

--- a/configs/gnn/gat_pure_sigmoid.yaml
+++ b/configs/gnn/gat_pure_sigmoid.yaml
@@ -1,0 +1,43 @@
+MetaArguments:
+  log_file_path: "gat_pure_sigmoid.log"
+  node_file: "data/CrediBench/dec2024/vertices.csv"
+  edge_file: "data/CrediBench/dec2024/edges.csv"
+  target_file: "data/CrediBench/dec2024/targets.csv"
+  processed_location: "data/CrediBench/dec2024/processed_dir/pc1"
+  weights_directory: "data/weights_pure_sigmoid/"
+  database_folder: "data/CrediBench/dec2024/"
+
+  target_col: "pc1"
+  target_index_name: 'nid'
+  target_index_col: 0
+  edge_src_col: "src"
+  edge_dst_col: "dst"
+  index_col: 0
+  encoder_dict:
+    pre: PRE
+  embedding_index_file: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m/dec2024_wetcontent_domains_index.pkl"
+  embedding_folder: "data/CrediBench/content_embedding/dec2024/embeddinggema-300m"
+  is_scratch_location: false
+  global_seed: 42
+
+
+ExperimentArguments:
+  exp_args:
+    GAT_pure_sigmoid:
+      model_args:
+        model: "GAT"
+        num_layers: 3
+        hidden_channels: 256
+        num_neighbors: [30, 30, 30]
+        batch_size: 1024
+        dropout: 0.1
+        lr: 0.001
+        epochs: 100
+        runs: 1
+        device: 0
+        log_steps: 10
+        predictor_type: "pure_sigmoid"
+      data_args:
+        task_name: "node-regression"
+        is_regression: true
+        num_test_shards: 2

--- a/credipred/experiments/gnn_experiments/gnn_experiment.py
+++ b/credipred/experiments/gnn_experiments/gnn_experiment.py
@@ -220,6 +220,8 @@ def run_gnn_baseline(
             out_channels=model_arguments.embedding_dimension,
             num_layers=model_arguments.num_layers,
             dropout=model_arguments.dropout,
+            # Predictor head type
+            predictor_type=model_arguments.predictor_type,
         ).to(device)
         optimizer = torch.optim.AdamW(model.parameters(), lr=model_arguments.lr)
         loss_tuple_epoch_mse: List[Tuple[float, float, float, float, float]] = []

--- a/credipred/experiments/gnn_experiments/weak_supervision_experiment.py
+++ b/credipred/experiments/gnn_experiments/weak_supervision_experiment.py
@@ -56,6 +56,7 @@ def run_weak_supervision_forward(
         out_channels=model_arguments.embedding_dimension,
         num_layers=model_arguments.num_layers,
         dropout=model_arguments.dropout,
+        predictor_type=model_arguments.predictor_type,
     ).to(device)
     model.load_state_dict(torch.load(weight_path, map_location=device))
     logging.info('Model Loaded.')

--- a/credipred/gnn/model.py
+++ b/credipred/gnn/model.py
@@ -41,6 +41,8 @@ class Model(torch.nn.Module):
         out_channels: int,
         num_layers: int,
         dropout: float,
+        # Predictor head type
+        predictor_type: str = 'relu_sigmoid',
     ):
         super().__init__()
         self.model_name = model_name
@@ -66,7 +68,9 @@ class Model(torch.nn.Module):
         self.output_linear = nn.Linear(
             in_features=hidden_channels, out_features=out_channels
         )
-        self.node_predictor = NodePredictor(in_dim=out_channels, out_dim=1)
+        self.node_predictor = NodePredictor(
+            in_dim=out_channels, out_dim=1, predictor_type=predictor_type
+        )
 
     def forward(self, x: Tensor, edge_index: Tensor | None = None) -> Tensor:
         x = self.input_linear(x)

--- a/credipred/utils/args.py
+++ b/credipred/utils/args.py
@@ -184,6 +184,15 @@ class ModelArguments:
     log_steps: int = field(
         default=50, metadata={'help': 'Step mod epoch to print logger.'}
     )
+    # Predictor head type
+    predictor_type: str = field(
+        default='relu_sigmoid',
+        metadata={
+            'help': "Predictor head type. Choices: 'relu_sigmoid' (original), "
+            "'leaky_sigmoid' (LeakyReLU+Sigmoid), 'pure_sigmoid' (GELU+Sigmoid), "
+            "'no_sigmoid' (GELU only, unconstrained output)."
+        },
+    )
 
 
 @dataclass

--- a/run_bronode/gat-leaky-sigmoid.job
+++ b/run_bronode/gat-leaky-sigmoid.job
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=GAT_leaky_sigmoid
+#SBATCH --output=slurm_logs/gps/gat-leaky-sigmoid-%j.out
+#SBATCH --error=slurm_logs/gps/gat-leaky-sigmoid-%j.err
+#SBATCH --time=23:59:59
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=250G
+#SBATCH --cpus-per-task=16
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Starting GAT LeakySigmoid Experiment on $(hostname) at $(date)"
+echo "Current working directory: $(pwd)"
+
+uv run ./credipred/experiments/gnn_experiments/main.py \
+    --config-file configs/gnn/gat_leaky_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"

--- a/run_bronode/gat-no-sigmoid.job
+++ b/run_bronode/gat-no-sigmoid.job
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=GAT_no_sigmoid
+#SBATCH --output=slurm_logs/gps/gat-no-sigmoid-%j.out
+#SBATCH --error=slurm_logs/gps/gat-no-sigmoid-%j.err
+#SBATCH --time=23:59:59
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=250G
+#SBATCH --cpus-per-task=16
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Starting GAT NoSigmoid Experiment on $(hostname) at $(date)"
+echo "Current working directory: $(pwd)"
+
+uv run ./credipred/experiments/gnn_experiments/main.py \
+    --config-file configs/gnn/gat_no_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"

--- a/run_bronode/gat-pure-sigmoid.job
+++ b/run_bronode/gat-pure-sigmoid.job
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=GAT_pure_sigmoid
+#SBATCH --output=slurm_logs/gps/gat-pure-sigmoid-%j.out
+#SBATCH --error=slurm_logs/gps/gat-pure-sigmoid-%j.err
+#SBATCH --time=23:59:59
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=250G
+#SBATCH --cpus-per-task=16
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Starting GAT PureSigmoid Experiment on $(hostname) at $(date)"
+echo "Current working directory: $(pwd)"
+
+uv run ./credipred/experiments/gnn_experiments/main.py \
+    --config-file configs/gnn/gat_pure_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"

--- a/run_bronode/get-pred-dist-leaky.job
+++ b/run_bronode/get-pred-dist-leaky.job
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH --job-name=pred_dist_leaky
+#SBATCH --output=slurm_logs/gps/pred-dist-leaky-%j.out
+#SBATCH --error=slurm_logs/gps/pred-dist-leaky-%j.err
+#SBATCH --time=01:00:00
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=64G
+#SBATCH --cpus-per-task=8
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Getting prediction distributions for GAT LeakySigmoid on $(hostname) at $(date)"
+
+uv run ./credipred/experiments/gnn_experiments/get_prediction_target_distributions.py \
+    --config-file configs/gnn/gat_leaky_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"

--- a/run_bronode/get-pred-dist-no-sigmoid.job
+++ b/run_bronode/get-pred-dist-no-sigmoid.job
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH --job-name=pred_dist_no_sig
+#SBATCH --output=slurm_logs/gps/pred-dist-no-sigmoid-%j.out
+#SBATCH --error=slurm_logs/gps/pred-dist-no-sigmoid-%j.err
+#SBATCH --time=01:00:00
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=64G
+#SBATCH --cpus-per-task=8
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Getting prediction distributions for GAT NoSigmoid on $(hostname) at $(date)"
+
+uv run ./credipred/experiments/gnn_experiments/get_prediction_target_distributions.py \
+    --config-file configs/gnn/gat_no_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"

--- a/run_bronode/get-pred-dist-pure-sigmoid.job
+++ b/run_bronode/get-pred-dist-pure-sigmoid.job
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH --job-name=pred_dist_pure
+#SBATCH --output=slurm_logs/gps/pred-dist-pure-sigmoid-%j.out
+#SBATCH --error=slurm_logs/gps/pred-dist-pure-sigmoid-%j.err
+#SBATCH --time=01:00:00
+#SBATCH --qos=medium
+#SBATCH --gres=gpu:1
+#SBATCH --exclude=klein
+#SBATCH --mem=64G
+#SBATCH --cpus-per-task=8
+#SBATCH --partition=h100
+
+cd /slurm-storage/jiaxio/ws/CrediPred
+
+echo "Getting prediction distributions for GAT PureSigmoid on $(hostname) at $(date)"
+
+uv run ./credipred/experiments/gnn_experiments/get_prediction_target_distributions.py \
+    --config-file configs/gnn/gat_pure_sigmoid.yaml
+
+echo "Completed on $(hostname) at $(date)"


### PR DESCRIPTION
- Modify NodePredictor in modules.py to support 4 predictor types:
  - relu_sigmoid: original ReLU + Sigmoid (default)
  - leaky_sigmoid: LeakyReLU + Sigmoid (allows small negative values through)
  - pure_sigmoid: GELU + Sigmoid (smooth activation)
  - no_sigmoid: GELU only (unconstrained output)
- Add predictor_type parameter to Model and ModelArguments
- Add config files and job scripts for GAT experiments with each predictor type